### PR TITLE
Feature/departure time original response object

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Note that you will need to pass a valid Here apiKey to the constructor.
 | avoidTolls    | boolean | false   | |
 | avoidFerries  | boolean | false   | |
 | avoidDirtRoad | boolean | false   | |
-| departureTime | string  | null    |  [Available options](https://developer.here.com/documentation/routing-api/api-reference-swagger.html) |
+| departureTime | string  | any     |  [Available options](https://developer.here.com/documentation/routing-api/api-reference-swagger.html) |
 | transportMode | string  | car     |  [Available options](https://developer.here.com/documentation/routing-api/api-reference-swagger.html) |
 | routingMode   | string  | fast    |  [Available options](https://developer.here.com/documentation/routing-api/api-reference-swagger.html) |
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Note that you will need to pass a valid Here apiKey to the constructor.
 | avoidTolls    | boolean | false   | |
 | avoidFerries  | boolean | false   | |
 | avoidDirtRoad | boolean | false   | |
-| trafficMode   | boolean | false   | |
+| departureTime | string  | null    |  [Available options](https://developer.here.com/documentation/routing-api/api-reference-swagger.html) |
 | transportMode | string  | car     |  [Available options](https://developer.here.com/documentation/routing-api/api-reference-swagger.html) |
 | routingMode   | string  | fast    |  [Available options](https://developer.here.com/documentation/routing-api/api-reference-swagger.html) |
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leaflet-routing-machine-here",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Support for here in Leaflet Routing Machine, including route restrictions",
   "main": "dist/lrm-here.js",
   "scripts": {

--- a/src/L.Routing.Here.js
+++ b/src/L.Routing.Here.js
@@ -14,6 +14,7 @@
 			serviceUrl: 'https://router.hereapi.com/v8/routes',
 			timeout: 30 * 1000,
 			noticesTypeAsRouteError: ['critical'], 
+      alternatives: 0,
 			urlParameters: {},
 			routeRestriction: {
 				transportMode: 'car',
@@ -113,7 +114,8 @@
 						totalTime: 0,
 					},
 					inputWaypoints,
-					waypoints: []
+					waypoints: [],
+					originalRouteObject: route,
 				};
 
 				return route.sections.reduce((acc, section, index) => {
@@ -154,10 +156,11 @@
 				apiKey: this._apiKey,
 				transportMode: mode,
 				routingMode: this.options.routeRestriction.routeMode || 'fast',
-				departureTime: this.options.routeRestriction.trafficMode === false ? 'any' : null,
+				departureTime: this.options.routeRestriction.departureTime ?? null,
 				avoid: {
 					features: this._buildAvoidFeatures(this.options)
 				},
+        alternatives: this.options.alternatives,
 				vehicle: vehicleRestrictions
 			}, this.options.urlParameters);
 			

--- a/src/L.Routing.Here.js
+++ b/src/L.Routing.Here.js
@@ -14,7 +14,7 @@
 			serviceUrl: 'https://router.hereapi.com/v8/routes',
 			timeout: 30 * 1000,
 			noticesTypeAsRouteError: ['critical'], 
-      alternatives: 0,
+			alternatives: 0,
 			urlParameters: {},
 			routeRestriction: {
 				transportMode: 'car',
@@ -82,14 +82,14 @@
 				const routeCriticalNotices = [];
 
 				response.routes.forEach((route) =>
-          route.sections.forEach((section) =>
-            (section.notices || []).forEach((notice) => {
-              if (this.options.noticesTypeAsRouteError.includes(notice.severity)) {
+					route.sections.forEach((section) =>
+						(section.notices || []).forEach((notice) => {
+							if (this.options.noticesTypeAsRouteError.includes(notice.severity)) {
 								routeCriticalNotices.push(notice);
 							}
 						})
-          )
-        );
+					)
+				);
 
 				if (routeCriticalNotices.length > 0) {
 					callback.call(context, {
@@ -160,7 +160,7 @@
 				avoid: {
 					features: this._buildAvoidFeatures(this.options)
 				},
-        alternatives: this.options.alternatives,
+				alternatives: this.options.alternatives,
 				vehicle: vehicleRestrictions
 			}, this.options.urlParameters);
 			

--- a/src/L.Routing.Here.js
+++ b/src/L.Routing.Here.js
@@ -156,7 +156,7 @@
 				apiKey: this._apiKey,
 				transportMode: mode,
 				routingMode: this.options.routeRestriction.routeMode || 'fast',
-				departureTime: this.options.routeRestriction.departureTime ?? null,
+				departureTime: this.options.routeRestriction.hasOwnProperty('departureTime') ? this.options.routeRestriction.departureTime : 'any',
 				avoid: {
 					features: this._buildAvoidFeatures(this.options)
 				},


### PR DESCRIPTION
Oryginalny obiekt route z response jest potrzebny, ponieważ w aplikacj chcemy go dalej analizować. 